### PR TITLE
add encoding as parameter

### DIFF
--- a/fool/__init__.py
+++ b/fool/__init__.py
@@ -80,8 +80,8 @@ def pos_cut(text):
     return word_inf
 
 
-def load_userdict(path):
-    _DICTIONARY.add_dict(path)
+def load_userdict(path, encoding='utf-8'):
+    _DICTIONARY.add_dict(path, encoding)
 
 
 def delete_userdict():

--- a/fool/dictionary.py
+++ b/fool/dictionary.py
@@ -15,10 +15,10 @@ class Dictionary():
         self.weights = {}
         self.sizes = 0
 
-    def add_dict(self, path):
+    def add_dict(self, path, encoding):
         words = []
 
-        with open(path) as f:
+        with open(path, encoding=encoding) as f:
             for i, line in enumerate(f):
                 line = line.strip("\n").strip()
                 if not line:


### PR DESCRIPTION
It needs an extra parameter to set encoding in `load_userdict()`.

The default encoding of `open()` in Python depends on system (or shell); it may be utf-8 on Linux while ANSI on Windows (cmd.exe).
Sometimes it will cause an error.
For example, if there is a file encoded in UTF-8, then it cannot open by `fool.load_userdict()` on Windows.